### PR TITLE
Update VMXa.asm

### DIFF
--- a/src/Arch/Intel/VMXa.asm
+++ b/src/Arch/Intel/VMXa.asm
@@ -24,6 +24,64 @@ extern RtlCaptureContext:proc
 
 .CODE
 
+; Our own function to restore context from CONTEXT structure (alternative to a BSODing RtlRestoreContext() function; compatibility with original RtlCaptureContext() function).
+
+VmRestoreContext PROC
+
+	push rbp
+	push rsi
+	push rdi
+	sub rsp, 30h
+	mov rbp, rsp
+	movaps  xmm0, xmmword ptr [rcx+1A0h]
+	movaps  xmm1, xmmword ptr [rcx+1B0h]
+	movaps  xmm2, xmmword ptr [rcx+1C0h]
+	movaps  xmm3, xmmword ptr [rcx+1D0h]
+	movaps  xmm4, xmmword ptr [rcx+1E0h]
+	movaps  xmm5, xmmword ptr [rcx+1F0h]
+	movaps  xmm6, xmmword ptr [rcx+200h]
+	movaps  xmm7, xmmword ptr [rcx+210h]
+	movaps  xmm8, xmmword ptr [rcx+220h]
+	movaps  xmm9, xmmword ptr [rcx+230h]
+	movaps  xmm10, xmmword ptr [rcx+240h]
+	movaps  xmm11, xmmword ptr [rcx+250h]
+	movaps  xmm12, xmmword ptr [rcx+260h]
+	movaps  xmm13, xmmword ptr [rcx+270h]
+	movaps  xmm14, xmmword ptr [rcx+280h]
+	movaps  xmm15, xmmword ptr [rcx+290h]
+	ldmxcsr dword ptr [rcx+34h]
+
+	mov     ax, [rcx+42h]
+	mov     [rsp+20h], ax
+	mov     rax, [rcx+98h] ; RSP
+	mov     [rsp+18h], rax
+	mov     eax, [rcx+44h]
+	mov     [rsp+10h], eax
+	mov     ax, [rcx+38h]
+	mov     [rsp+08h], ax
+	mov     rax, [rcx+0F8h] ; RIP
+	mov     [rsp+00h], rax ; set RIP as return address (for iretq instruction).
+
+	mov     rax, [rcx+78h]
+	mov     rdx, [rcx+88h]
+	mov     r8, [rcx+0B8h]
+	mov     r9, [rcx+0C0h]
+	mov     r10, [rcx+0C8h]
+	mov     r11, [rcx+0D0h]
+	cli
+	mov     rbx, [rcx+90h]
+	mov     rsi, [rcx+0A8h]
+	mov     rdi, [rcx+0B0h]
+	mov     rbp, [rcx+0A0h]
+	mov     r12, [rcx+0D8h]
+	mov     r13, [rcx+0E0h]
+	mov     r14, [rcx+0E8h]
+	mov     r15, [rcx+0F0h]
+	mov     rcx, [rcx+80h]
+	iretq
+
+VmRestoreContext ENDP
+
 VmxVMEntry PROC
     push    rcx                 ; save RCX, as we will need to orverride it
     lea     rcx, [rsp+8h]       ; store the context in the stack, bias for


### PR DESCRIPTION
to fix KERNEL_SECURITY_CHECK_FAILURE BSOD on Win10 15063+