### PR TITLE
Update VmxExitHandlers.c

### DIFF
--- a/src/Arch/Intel/VmxExitHandlers.c
+++ b/src/Arch/Intel/VmxExitHandlers.c
@@ -178,7 +178,7 @@ DECLSPEC_NORETURN EXTERN_C VOID VmxpExitHandler( IN PCONTEXT Context )
     }
 
     KeLowerIrql( guestContext.GuestIrql );
-    RtlRestoreContext( Context, NULL );
+    VmRestoreContext( Context );
 }
 
 /// <summary>


### PR DESCRIPTION
to fix KERNEL_SECURITY_CHECK_FAILURE BSOD on Win10 15063+